### PR TITLE
Improve Dockerfile and add better build/deploy docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM public.ecr.aws/lambda/ruby:3.2
 
-WORKDIR ${LAMBDA_TASK_ROOT}
-COPY . ${LAMBDA_TASK_ROOT}
-
 ENV LANG=en_US.UTF-8
 
-RUN #yum install -y ruby3.2.x86_64 ruby3.2-devel.x86_64 \
 RUN yum install -y ruby3.2-devel.x86_64 libyaml-devel.x86_64
 RUN yum groupinstall "Development Tools" -y
 
-ENTRYPOINT "bash"
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+ENTRYPOINT ["bash", "-c"]
 CMD ["/var/task/.buildkite/bundle.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# env-reservation-bot
+
+## Deployment instructions
+
+1. `docker compose run --rm compile`
+  - Download and compile gems into the `vendor` directory using the same Ruby environment as the lambda runtime
+1. `aws-vault exec <Shared-Services profile> docker -- compose run --rm serverless sls deploy --verbose`
+  - Deploy the lambdas with serverless
+
+The application depends on the following parameters to be available in the parameter store of the account and region:
+
+- /reservationbot/slack.bot.oauth.token - from https://api.slack.com/apps/YOURAPP/oauth
+- /reservationbot/slack.verification.token from https://api.slack.com/apps/YOURAPP/general
+- /reservationbot/supported.envs - set this as a comma separated list

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     platform: "linux/amd64"
     image: amaysim/serverless:3.36.0
     command: serverless
+    working_dir: /opt/app/
     volumes:
     - .:/opt/app
     environment:


### PR DESCRIPTION
This PR improves the Dockerfile by removing unnecessary steps, and fixing the entrypoint script. Previously the Dockerfile copied the repo contents into the image. This isn't necessary, as compose file already bind mounts the repo root to the correct working directory. The entrypoint did not work, so attempting to compile the dependencies wouldn't work.

I've also documented the build and deployment instructions more clearly. Previously they were in `.buildkite/notes.txt` but this isn't an obvious place to check, and the instructions didn't work due to the issue with the Dockerfile mentioned above. I also wanted to make clear the need to use `aws-vault` and the shared services profile to deploy.